### PR TITLE
Add workflow to publish jsdoc

### DIFF
--- a/.github/workflows/publish_jsdoc.yml
+++ b/.github/workflows/publish_jsdoc.yml
@@ -1,0 +1,27 @@
+name: Publish JSDoc
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build
+        uses: andstor/jsdoc-action@v1
+        with:
+          source_dir: ./
+          output_dir: ./jsdoc
+          template: docdash
+          front_page: ./README.md
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./jsdoc


### PR DESCRIPTION
This adds a github actions workflow that builds the jsdoc content and publishes it via gh pages.