### PR TITLE
Add Stacking reward info

### DIFF
--- a/getstackinginfo.js
+++ b/getstackinginfo.js
@@ -5,6 +5,7 @@ import {
   getBlockHeight,
   getRewardCycle,
   getStackerAtCycleOrDefault,
+  getStackingReward,
   getUserId,
   printDivider,
   printTimeStamp,
@@ -113,6 +114,9 @@ async function getStackingInfo() {
 
   if (userConfig.searchAllCycles) {
     console.log(`Checking cycles 1 to ${currentCycle + maxCycles}...`);
+    console.log(
+      `Note: stxReward will show 0 unless there are rewards to claim`
+    );
     let i = 0;
     do {
       const stacker = await getStackerAtCycleOrDefault(
@@ -121,11 +125,21 @@ async function getStackingInfo() {
         i + 1,
         userId
       );
+      let stackingReward = 0;
+      if (i <= currentCycle) {
+        stackingReward = await getStackingReward(
+          userConfig.contractAddress,
+          userConfig.contractName,
+          i + 1,
+          userId
+        );
+      }
       stackingStats.push({
         CityCoin: userConfig.tokenSymbol,
         Cycle: i + 1,
         amountStacked: parseInt(stacker.value.amountStacked.value),
         toReturn: parseInt(stacker.value.toReturn.value),
+        stxReward: stackingReward,
       });
       if (i > currentCycle) {
         if (parseInt(stacker.value.amountStacked.value) === 0) {
@@ -137,7 +151,16 @@ async function getStackingInfo() {
     } while (i < currentCycle + maxCycles);
   } else {
     console.log(`Checking cycle ${userConfig.targetCycle}...`);
+    console.log(
+      `Note: stxReward will show 0 unless there are rewards to claim`
+    );
     const stacker = await getStackerAtCycleOrDefault(
+      userConfig.contractAddress,
+      userConfig.contractName,
+      userConfig.targetCycle,
+      userId
+    );
+    const stackingReward = await getStackingReward(
       userConfig.contractAddress,
       userConfig.contractName,
       userConfig.targetCycle,
@@ -148,6 +171,7 @@ async function getStackingInfo() {
       Cycle: userConfig.targetCycle,
       amountStacked: parseInt(stacker.value.amountStacked.value),
       toReturn: parseInt(stacker.value.toReturn.value),
+      stxReward: stackingReward,
     });
   }
 

--- a/utils.js
+++ b/utils.js
@@ -349,6 +349,24 @@ export async function getStackerAtCycleOrDefault(
   return result;
 }
 
+export async function getStackingReward(
+  contractAddress,
+  contractName,
+  cycleId,
+  userId
+) {
+  const resultCv = await callReadOnlyFunction({
+    contractAddress: contractAddress,
+    contractName: contractName,
+    functionName: "get-stacking-reward",
+    functionArgs: [uintCV(userId), uintCV(cycleId)],
+    network: STACKS_NETWORK,
+    senderAddress: contractAddress,
+  });
+  const result = cvToJSON(resultCv);
+  return result.value;
+}
+
 /**
  * @async
  * @function getUserId

--- a/utils.js
+++ b/utils.js
@@ -349,6 +349,16 @@ export async function getStackerAtCycleOrDefault(
   return result;
 }
 
+/**
+ * @async
+ * @function getStackingReward
+ * @param {string} contractAddress
+ * @param {string} contractName
+ * @param {integer} cycleId
+ * @param {integer} userId
+ * @description Returns the amount of STX a user can claim in a given reward cycle in uSTX.
+ * @returns {integer}
+ */
 export async function getStackingReward(
   contractAddress,
   contractName,
@@ -364,7 +374,7 @@ export async function getStackingReward(
     senderAddress: contractAddress,
   });
   const result = cvToJSON(resultCv);
-  return result.value;
+  return parseInt(result.value);
 }
 
 /**


### PR DESCRIPTION
This PR adds the `getStackingReward` function to the utils and uses that to calculate a `stxReward` column.

This function returns the amount of STX a user can claim in a given reward cycle in uSTX.

This method will only return a positive value if:

- the current block height is in the next reward cycle
- the Stacker locked up CityCoins in the target reward cycle
- the Stacker locked up enough CityCoins to receive at least one uSTX

**Note: `stxReward` will show 0 unless there are rewards to claim**

https://docs.citycoins.co/contract-functions/stacking#get-stacking-reward