### PR TITLE
Add script to automatically claim mining rewards

### DIFF
--- a/autominer.js
+++ b/autominer.js
@@ -476,7 +476,7 @@ async function autoMine(userConfig, miningStrategy = {}, firstRun = true) {
           sumCV.value
         ),
       ],
-      STACKS_NETWORK,
+      network: STACKS_NETWORK,
     };
 
     // pause 10sec
@@ -531,6 +531,4 @@ console.log(warn("USE AT YOUR OWN RISK. PLEASE REPORT ANY ISSUES ON GITHUB."));
 printDivider();
 console.log(title("STATUS: SETTING USER CONFIG"));
 printDivider();
-promptUserConfig().then((answers) => {
-  autoMine(answers);
-});
+promptUserConfig().then((answers) => autoMine(answers));

--- a/autominer.js
+++ b/autominer.js
@@ -16,6 +16,7 @@ import {
   getOptimalFee,
   getNonce,
   STACKS_NETWORK,
+  cancelPrompt,
 } from "./utils.js";
 import {
   uintCV,
@@ -28,15 +29,6 @@ import {
 } from "@stacks/transactions";
 
 /** @module AutoMiner */
-
-/**
- * @function cancel
- * @param {Object[]} prompt An object that contains the current prompt displayed to the user
- * @description Catches a cancel event in prompts, sets the message, and exits the AutoMiner
- */
-const cancel = (prompt) => {
-  exitWithError(`ERROR: cancelled by user at ${prompt.name}, exiting...`);
-};
 
 /**
  * @async
@@ -150,7 +142,7 @@ async function promptUserConfig() {
     }
   };
   const userConfig = await prompts(questions, {
-    onCancel: cancel,
+    onCancel: cancelPrompt,
     onSubmit: submit,
   });
   return userConfig;
@@ -191,7 +183,7 @@ async function promptMiningStrategy() {
     },
   ];
   const miningStrategy = await prompts(miningStrategyQuestions, {
-    onCancel: cancel,
+    onCancel: cancelPrompt,
   });
   // verify max commit set by user or exit
   const confirmMax = await prompts(
@@ -203,7 +195,7 @@ async function promptMiningStrategy() {
       ).toFixed(6)} STX?`,
     },
     {
-      onCancel: cancel,
+      onCancel: cancelPrompt,
     }
   );
   if (!confirmMax) {
@@ -228,7 +220,7 @@ async function promptFeeStrategy() {
       validate: (value) => (value > 0 ? true : "Value must be greater than 0"),
     },
     {
-      onCancel: cancel,
+      onCancel: cancelPrompt,
     }
   );
   return feeMultiplier;
@@ -274,7 +266,7 @@ async function autoMine(userConfig, miningStrategy = {}, firstRun = true) {
           ).toFixed(6)} STX`,
         },
         {
-          onCancel: cancel,
+          onCancel: cancelPrompt,
         }
       );
       // exit if not confirmed
@@ -310,7 +302,7 @@ async function autoMine(userConfig, miningStrategy = {}, firstRun = true) {
           ).toFixed(6)} STX`,
         },
         {
-          onCancel: cancel,
+          onCancel: cancelPrompt,
         }
       );
       if (!confirmFee) {

--- a/autominingclaimer.js
+++ b/autominingclaimer.js
@@ -1,0 +1,215 @@
+import BN from "bn.js";
+import prompts from "prompts";
+import {
+  cancelPrompt,
+  getBlockHeight,
+  printDivider,
+  printTimeStamp,
+  timer,
+  USTX,
+  title,
+  exitWithError,
+  getNonce,
+  STACKS_NETWORK,
+  canClaimMiningReward,
+  safeFetch,
+} from "./utils.js";
+import {
+  uintCV,
+  PostConditionMode,
+  makeContractCall,
+  broadcastTransaction,
+} from "@stacks/transactions";
+
+/** @module AutoMiningClaimer */
+
+/**
+ * @constant
+ * @type {integer}
+ * @description Default fee to use when no custom fee is set
+ * @default
+ */
+const defaultFee = 50000;
+
+/**
+ * @async
+ * @function promptUserConfig
+ * @description Prompts the user for configuration options at the start of the script
+ * @returns {Object[]} An object that contains properties for each question name and related answers as a values
+ */
+async function promptUserConfig() {
+  const questions = [
+    {
+      type: "select",
+      name: "citycoin",
+      message: "Select a CityCoin to look up mining claims:",
+      choices: [
+        { title: "MiamiCoin (MIA)", value: "MIA" },
+        { title: "NewYorkCityCoin (NYC)", value: "NYC" },
+      ],
+    },
+    {
+      type: "text",
+      name: "stxAddress",
+      message: "Stacks Address to claim with?",
+      validate: (value) => (value === "" ? "Stacks address is required" : true),
+    },
+    {
+      type: "password",
+      name: "stxPrivateKey",
+      message: "Private Key for Stacks Address?",
+      validate: (value) =>
+        value === "" ? "Stacks private key is required" : true,
+    },
+    {
+      type: "confirm",
+      name: "customFee",
+      message: `Set custom fee? (default ${(defaultFee / USTX).toFixed(
+        6
+      )} STX)`,
+    },
+    {
+      type: (prev) => (prev ? "number" : null),
+      name: "customFeeValue",
+      message: "Custom fee value in uSTX? (1,000,000 uSTX = 1 STX)",
+      validate: (value) => (value > 0 ? true : "Value must be greater than 0"),
+    },
+  ];
+  const submit = (prompt, answer, answers) => {
+    if (prompt.name === "citycoin") {
+      switch (answer) {
+        case "MIA":
+          answers.contractAddress = "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27";
+          answers.contractName = "miamicoin-core-v1";
+          answers.blockWinnersUrl = "https://miamining.com/winners";
+          break;
+        case "NYC":
+          answers.contractAddress = "SP2H8PY27SEZ03MWRKS5XABZYQN17ETGQS3527SA5";
+          answers.contractName = "newyorkcitycoin-core-v1";
+          answers.blockWinnersUrl = "https://mining.nyc/winners";
+          break;
+      }
+    }
+  };
+  const userConfig = await prompts(questions, {
+    onCancel: cancelPrompt,
+    onSubmit: submit,
+  });
+  return userConfig;
+}
+
+async function autoMiningClaimer(userConfig) {
+  printDivider();
+  printTimeStamp();
+
+  const currentBlockHeight = await getBlockHeight().catch((err) =>
+    exitWithError(`getBlockHeight err: ${err}`)
+  );
+  console.log(`currentBlockHeight: ${currentBlockHeight}`);
+
+  const blockWinners = await safeFetch(userConfig.blockWinnersUrl);
+
+  // get all blocks won from Jamils explorer
+  const blocksWon = [];
+  const blocksUnclaimed = [];
+  for (const block in blockWinners) {
+    if (blockWinners[block].miner === userConfig.stxAddress) {
+      blocksWon.push(block);
+      if (!blockWinners[block].claimed) {
+        blocksUnclaimed.push(block);
+      }
+    }
+  }
+
+  // double-check that blocksUnclaimed is accurate by querying the contract for each block height
+  console.log(`Checking unclaimed blocks...`);
+  const blocksUnclaimedCheck = await Promise.all(
+    blocksUnclaimed.map(async (block) => {
+      // pause between requests
+      await timer(1000);
+      // check if user can claim mining reward
+      return canClaimMiningReward(
+        userConfig.contractAddress,
+        userConfig.contractName,
+        userConfig.stxAddress,
+        block
+      ).catch((err) => exitWithError(`canClaimMiningReward err: ${err}`));
+    })
+  );
+
+  const blocksFiltered = blocksUnclaimed.filter(
+    (value, idx) => blocksUnclaimedCheck[idx]
+  );
+
+  console.log(`Total blocks to claim: ${blocksFiltered.length}`);
+
+  printDivider();
+  console.log(title("STATUS: CLAIMING MINING REWARDS"));
+
+  // get the current nonce
+  let nonce = await getNonce(userConfig.stxAddress).catch((err) =>
+    exitWithError(`getNonce err: ${err}`)
+  );
+
+  const counterLimit = blocksFiltered.length < 24 ? blocksFiltered.length : 24;
+  for (let i = 0; i < counterLimit; i++) {
+    printDivider();
+    console.log(
+      `account: ${userConfig.stxAddress.slice(
+        0,
+        5
+      )}...${userConfig.stxAddress.slice(userConfig.stxAddress.length - 5)}`
+    );
+    console.log(`nonce: ${nonce}`);
+    console.log(`claiming block: ${blocksFiltered[i]}`);
+    // create the claim tx
+    const txOptions = {
+      contractAddress: userConfig.contractAddress,
+      contractName: userConfig.contractName,
+      contractFunction: "claim-mining-reward",
+      functionArgs: [uintCV(blocksFiltered[i])],
+      senderKey: userConfig.stxPrivateKey,
+      fee: new BN(
+        userConfig.hasOwnProperty("customFeeValue")
+          ? customFeeValue
+          : defaultFee
+      ),
+      nonce: new BN(nonce),
+      postConditionMode: PostConditionMode.Deny,
+      postConditions: [],
+      network: STACKS_NETWORK,
+    };
+
+    // pause 2sec
+    console.log(`pausing 2sec before submit`);
+    await timer(2000);
+
+    // submit the tx
+    const transaction = await makeContractCall(txOptions).catch((err) =>
+      exitWithError(`makeContractCall err: ${err}`)
+    );
+    const result = await broadcastTransaction(
+      transaction,
+      STACKS_NETWORK
+    ).catch((err) => exitWithError(`broadcastTransaction err: ${err}`));
+  }
+}
+
+// show title and disclaimer on first run
+printDivider();
+console.log(title("CITYCOINS AUTOMININGCLAIMER"));
+printDivider();
+console.log(
+  "This utility provides a simple, easy-to-use, prompt-driven interface for checking if an address won any blocks, and if so, automatically submits the claim transaction.\n"
+);
+console.log(
+  "THIS IS ALPHA SOFTWARE THAT REQUIRES A STACKS PRIVATE KEY TO SEND A TRANSACTION.\n"
+);
+console.log("THE CODE IS FOR EDUCATIONAL AND DEMONSTRATION PURPOSES ONLY.\n");
+console.log(warn("USE AT YOUR OWN RISK. PLEASE REPORT ANY ISSUES ON GITHUB."));
+
+// get the user config and start the AutoClaimer
+printDivider();
+console.log(title("STATUS: SETTING USER CONFIG"));
+printDivider();
+promptUserConfig().then((answers) => autoMiningClaimer(answers));

--- a/autominingclaimer.js
+++ b/autominingclaimer.js
@@ -13,6 +13,7 @@ import {
   STACKS_NETWORK,
   canClaimMiningReward,
   safeFetch,
+  warn,
 } from "./utils.js";
 import {
   uintCV,
@@ -188,10 +189,10 @@ async function autoMiningClaimer(userConfig) {
     const transaction = await makeContractCall(txOptions).catch((err) =>
       exitWithError(`makeContractCall err: ${err}`)
     );
-    const result = await broadcastTransaction(
-      transaction,
-      STACKS_NETWORK
-    ).catch((err) => exitWithError(`broadcastTransaction err: ${err}`));
+    console.log(`https://explorer.stacks.co/txid/${transaction.txid()}`);
+    await broadcastTransaction(transaction, STACKS_NETWORK).catch((err) =>
+      exitWithError(`broadcastTransaction err: ${err}`)
+    );
   }
 }
 

--- a/autominingclaimer.js
+++ b/autominingclaimer.js
@@ -123,11 +123,16 @@ async function autoMiningClaimer(userConfig) {
   }
 
   // double-check that blocksUnclaimed is accurate by querying the contract for each block height
-  console.log(`Checking unclaimed blocks...`);
+  console.log(
+    `Checking unclaimed blocks... (est. ${(
+      (blocksUnclaimed.length * 5) /
+      60
+    ).toFixed()} minutes)`
+  );
   const blocksUnclaimedCheck = await Promise.all(
     blocksUnclaimed.map(async (block) => {
-      // pause between requests
-      await timer(1000);
+      // pause between requests to avoid rate limits
+      await timer(5000);
       // check if user can claim mining reward
       return canClaimMiningReward(
         userConfig.contractAddress,

--- a/autominingclaimer.js
+++ b/autominingclaimer.js
@@ -137,7 +137,7 @@ async function autoMiningClaimer(userConfig) {
     console.log(`block ${checkCounter + 1} of ${blocksUnclaimed.length}`);
     console.log(`block: ${blocksUnclaimed[checkCounter]}`);
     // pause between requests to avoid rate limits
-    await timer(1000);
+    // await timer(1000);
     // check if user can claim mining reward
     const canClaim = await canClaimMiningReward(
       userConfig.contractAddress,
@@ -202,8 +202,8 @@ async function autoMiningClaimer(userConfig) {
     };
 
     // pause 2sec
-    console.log(`pausing 2sec before submit`);
-    await timer(2000);
+    console.log(`pausing 1sec before submit`);
+    await timer(1000);
 
     // submit the tx
     const transaction = await makeContractCall(txOptions).catch((err) =>

--- a/autominingclaimer.js
+++ b/autominingclaimer.js
@@ -158,7 +158,8 @@ async function autoMiningClaimer(userConfig) {
     checkCounter < blocksUnclaimed.length
   );
 
-  console.log(`Total blocks to claim: ${blocksToClaim.length}`);
+  printDivider();
+  console.log(`total blocks to claim: ${blocksToClaim.length}`);
 
   printDivider();
   console.log(title("STATUS: CLAIMING MINING REWARDS"));
@@ -213,6 +214,9 @@ async function autoMiningClaimer(userConfig) {
       exitWithError(`broadcastTransaction err: ${err}`)
     );
   }
+
+  printDivider();
+  console.log(`No more blocks to claim or claim limit reached.`);
 }
 
 // show title and disclaimer on first run

--- a/autominingclaimer.js
+++ b/autominingclaimer.js
@@ -129,7 +129,7 @@ async function autoMiningClaimer(userConfig) {
   // double-check that blocksUnclaimed is accurate by querying the contract for each block height
   console.log(`Checking ${blocksUnclaimed.length} unclaimed blocks...`);
 
-  const claimLimit = 2;
+  const claimLimit = 24;
   const blocksToClaim = [];
   let checkCounter = 0;
   do {

--- a/autominingclaimer.js
+++ b/autominingclaimer.js
@@ -129,10 +129,6 @@ async function autoMiningClaimer(userConfig) {
   // double-check that blocksUnclaimed is accurate by querying the contract for each block height
   console.log(`Checking ${blocksUnclaimed.length} unclaimed blocks...`);
 
-  // build array until 25 claimable entries are hit
-  // then kick off loop to process 25 claims
-  // instead of checking all blocks at once
-
   const claimLimit = 2;
   const blocksToClaim = [];
   let checkCounter = 0;
@@ -161,36 +157,6 @@ async function autoMiningClaimer(userConfig) {
     blocksToClaim.length < claimLimit &&
     checkCounter < blocksUnclaimed.length
   );
-
-  /*
-
-  const blocksUnclaimedCheck = [];
-  let totalBlocksWon = 0;
-  for (let i = 0; i < blocksUnclaimed.length; i++) {
-    printDivider();
-    // pause between requests to avoid rate limits
-    console.log(`block: ${blocksUnclaimed[i]}`);
-    await timer(1000);
-    // check if user can claim mining reward
-    const canClaim = await canClaimMiningReward(
-      userConfig.contractAddress,
-      userConfig.contractName,
-      userConfig.stxAddress,
-      blocksUnclaimed[i]
-    ).catch((err) => exitWithError(`canClaimMiningReward err: ${err}`));
-    console.log(`canClaim: ${canClaim}`);
-    blocksUnclaimedCheck.push(canClaim);
-    canClaim && totalBlocksWon++;
-    console.log(`total: ${totalBlocksWon} out of ${blocksUnclaimed.length}`);
-  }
-
-  
-
-  const blocksFiltered = blocksUnclaimed.filter(
-    (value, idx) => blocksUnclaimedCheck[idx]
-  );
-
-  */
 
   console.log(`Total blocks to claim: ${blocksToClaim.length}`);
 

--- a/autominingclaimer.js
+++ b/autominingclaimer.js
@@ -100,6 +100,12 @@ async function promptUserConfig() {
   return userConfig;
 }
 
+/**
+ * @async
+ * @function autoMiningClaimer
+ * @param {Object[]} userConfig
+ * @description Searches for won blocks and submits the related claim transactions
+ */
 async function autoMiningClaimer(userConfig) {
   printDivider();
   printTimeStamp();
@@ -201,7 +207,7 @@ async function autoMiningClaimer(userConfig) {
       anchorMode: AnchorMode.Any,
     };
 
-    // pause 2sec
+    // pause 1sec
     console.log(`pausing 1sec before submit`);
     await timer(1000);
 

--- a/getstackinginfo.js
+++ b/getstackinginfo.js
@@ -1,6 +1,7 @@
 import console from "console";
 import prompts from "prompts";
 import {
+  cancelPrompt,
   exitWithError,
   getBlockHeight,
   getRewardCycle,
@@ -65,11 +66,8 @@ async function promptUserConfig() {
       }
     }
   };
-  const cancel = (prompt) => {
-    exitWithError(`ERROR: cancelled by user at ${prompt.name}, exiting...`);
-  };
   const userConfig = await prompts(questions, {
-    onCancel: cancel,
+    onCancel: cancelPrompt,
     onSubmit: submit,
   });
   return userConfig;

--- a/getstackinginfo.js
+++ b/getstackinginfo.js
@@ -106,7 +106,7 @@ async function getStackingInfo() {
     userConfig.contractName,
     userConfig.stxAddress
   ).catch((err) => exitWithError(`getUserId err: ${err}`));
-  console.log(`UserId: ${userId}`);
+  console.log(`userId: ${userId}`);
 
   printDivider();
 

--- a/info/autominingclaimer.md
+++ b/info/autominingclaimer.md
@@ -1,0 +1,28 @@
+# CityCoins AutoMiningClaimer <!-- omit in toc -->
+
+> THIS IS ALPHA SOFTWARE THAT REQUIRES A STACKS PRIVATE KEY TO SEND A TRANSACTION.
+>
+> THE CODE IS FOR EDUCATIONAL AND DEMONSTRATION PURPOSES ONLY.
+>
+> USE AT YOUR OWN RISK. PLEASE REPORT ANY [ISSUES ON GITHUB](https://github.com/citycoins/scripts/issues).
+
+This utility provides a simple, easy-to-use, prompt-driven interface for checking if an address won any blocks, and if so, automatically submits the claim transaction.
+
+- [Obtaining the Private Key](#obtaining-the-private-key)
+- [Running the AutoMiningClaimer](#running-the-autominingclaimer)
+
+## Obtaining the Private Key
+
+The private key is used to sign transactions, and is required to send a transaction from a given Stacks address.
+
+More details on how to obtain the private key [can be found here](./privatekey.md).
+
+## Running the AutoMiningClaimer
+
+The miner will prompt for information on the first transaction, and use the information to search for won blocks and submit the claim transaction.
+
+**Note:** This script does not check for the number of already pending transactions for an address, and stops after 25 transactions to prevent exceeding the chaining limit in the mempool.
+
+```bash
+node autominingclaimer.js
+```

--- a/info/autominingclaimer.md
+++ b/info/autominingclaimer.md
@@ -10,6 +10,9 @@ This utility provides a simple, easy-to-use, prompt-driven interface for checkin
 
 - [Obtaining the Private Key](#obtaining-the-private-key)
 - [Running the AutoMiningClaimer](#running-the-autominingclaimer)
+- [AutoMiningClaimer Configuration](#autominingclaimer-configuration)
+  - [User Config](#user-config)
+  - [How it Works](#how-it-works)
 
 ## Obtaining the Private Key
 
@@ -26,3 +29,31 @@ The miner will prompt for information on the first transaction, and use the info
 ```bash
 node autominingclaimer.js
 ```
+
+## AutoMiningClaimer Configuration
+
+### User Config
+
+| Name           | Prompt                                             | Desc                                      |
+| -------------- | -------------------------------------------------- | ----------------------------------------- |
+| citycoin       | Select a CityCoin to mine:                         | Sets target contract values in userConfig |
+| stxAddress     | Stacks Address to mine with?                       | Stacks address used for mining            |
+| stxPrivateKey  | Private Key for Stacks Address?                    | Hex encoded private key used to submit tx |
+| customFee      | Set custom fee?                                    | Confirm setting a custom fee              |
+| customFeeValue | Custom fee value in uSTX? (1,000,000 uSTX = 1 STX) | Set the custom fee in uSTX                |
+
+**Note:** both `contractAddress` and `contractName` are set as userConfig properties based on the `citycoin` selection
+
+### How it Works
+
+The AutoMiningClaimer will pull the winning blocks from the related CityCoins block explorer (thanks and s/o to @jamil!), then:
+
+- filter by the user's Stacks address
+- check each won block against the contract
+  _(using `can-claim-mining-reward`)_
+- build a list of up to 25 claim transactions
+- submit each of the claim transactions
+
+**Note:** The default fee is set to 0.1 STX, but can be changed to a custom value through the prompts or using the `defaultFee` constant.
+
+**Note:** this script queries the API heavily, and sometimes can fail due to a gateway timeout. If this happens, try running the script again or using a different API node.

--- a/utils.js
+++ b/utils.js
@@ -40,6 +40,15 @@ STACKS_NETWORK.coreApiUrl = "https://stacks-node-api.stacks.co";
 export const timer = (ms) => new Promise((res) => setTimeout(res, ms));
 
 /**
+ * @function cancelPrompt
+ * @param {Object[]} prompt An object that contains the current prompt displayed to the user
+ * @description Catches a cancel event in prompts, sets the message, and exits the AutoMiner
+ */
+export const cancelPrompt = (prompt) => {
+  exitWithError(`ERROR: cancelled by user at ${prompt.name}, exiting...`);
+};
+
+/**
  * @async
  * @function processTx
  * @param {TxBroadcastResult} broadcastedResult result from broadcastTransaction() in @stacks/transactions

--- a/utils.js
+++ b/utils.js
@@ -29,7 +29,8 @@ export const USTX = 1000000;
  * @default
  */
 export const STACKS_NETWORK = new StacksMainnet();
-STACKS_NETWORK.coreApiUrl = "https://stacks-node-api.stacks.co";
+STACKS_NETWORK.coreApiUrl = "http://157.245.221.74:3999";
+//STACKS_NETWORK.coreApiUrl = "https://stacks-node-api.stacks.co";
 //STACKS_NETWORK.coreApiUrl = "https://mainnet.syvita.org";
 
 /**

--- a/utils.js
+++ b/utils.js
@@ -29,8 +29,8 @@ export const USTX = 1000000;
  * @default
  */
 export const STACKS_NETWORK = new StacksMainnet();
-STACKS_NETWORK.coreApiUrl = "http://157.245.221.74:3999";
-//STACKS_NETWORK.coreApiUrl = "https://stacks-node-api.stacks.co";
+//STACKS_NETWORK.coreApiUrl = "http://157.245.221.74:3999";
+STACKS_NETWORK.coreApiUrl = "https://stacks-node-api.stacks.co";
 //STACKS_NETWORK.coreApiUrl = "https://mainnet.syvita.org";
 
 /**

--- a/utils.js
+++ b/utils.js
@@ -463,6 +463,16 @@ export async function getRewardCycle(
   return parseInt(result.value.value);
 }
 
+/**
+ * @async
+ * @function canClaimMiningReward
+ * @param {string} contractAddress
+ * @param {string} contractName
+ * @param {string} address
+ * @param {integer} blockHeight
+ * @description Returns true if the user can claim a reward for a given block height
+ * @returns {bool}
+ */
 export async function canClaimMiningReward(
   contractAddress,
   contractName,

--- a/utils.js
+++ b/utils.js
@@ -323,6 +323,8 @@ async function getBlockAvg(
       i
     );
     blockStats.push(result);
+    // avoid API rate limiting
+    await timer(1000);
   }
 
   const sum = blockStats.reduce((a, b) => parseInt(a) + parseInt(b), 0);


### PR DESCRIPTION
Thanks to @Jamil and the data exposed through both miamining.com and mining.nyc, this script does the following:

- takes user input via prompts
- filters won blocks from Jamil's data
- loops and verified if blocks can be claimed
- claims up to 25 blocks in one run

Note: this script does not take into account pending transactions, and the limit for one address in the mempool is 25. If there are more blocks to claim then that, wait for the first batch to process before running again.