### PR TITLE
Fix tx processing

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -57,7 +57,15 @@ export async function processTx(broadcastedResult, tx) {
     const txResult = await result.json();
 
     printDivider();
-    console.log(title(`TX STATUS: ${txResult.tx_status.toUpperCase()}`));
+    console.log(
+      title(
+        `TX STATUS: ${
+          txResult.hasOwnProperty("tx_status")
+            ? txResult.tx_status.toUpperCase()
+            : "PENDING"
+        }`
+      )
+    );
     printDivider();
     printTimeStamp();
     console.log(`https://explorer.stacks.co/txid/${txResult.tx_id}`);
@@ -78,8 +86,6 @@ export async function processTx(broadcastedResult, tx) {
       }
     }
     // pause for 30min before checking again
-    // await timer(1800000);
-    // temporarily 5min for testing
     await timer(300000);
     count++;
   } while (count < countLimit);

--- a/utils.js
+++ b/utils.js
@@ -29,7 +29,7 @@ export const USTX = 1000000;
  * @default
  */
 export const STACKS_NETWORK = new StacksMainnet();
-STACKS_NETWORK.coreApiUrl = "https://stacks-node-api.mainnet.stacks.co";
+STACKS_NETWORK.coreApiUrl = "https://stacks-node-api.stacks.co";
 
 /**
  * @async


### PR DESCRIPTION
When a tx is broadcasted it exists in the mempool for that node, but not for all nodes, and until it propagates the first few attempst at processing a tx may be undefined.

This PR adds an extra check to catch the undefined bit and output a different status.

Also some small code cleanup.